### PR TITLE
Fix target="blank" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Report to the President on IT Modernization
 
-**The comment period is closed.** All submitted comments during this period will be [**publicly posted here**](https://github.com/GSA/modernization/issues){:target="_blank"}.
+**The comment period is closed.** All submitted comments during this period will be <a href="https://github.com/GSA/modernization/issues" target="_blank">**publicly posted here**</a>.
 
 [Executive Order (EO) 13,800](https://www.whitehouse.gov/the-press-office/2017/05/11/presidential-executive-order-strengthening-cybersecurity-federal) tasks the Director of the American Technology Council (ATC) to coordinate a report to the President from the Secretary of the Department of Homeland Security (DHS), the Director of the Office of Management and Budget (OMB), and the Administrator of the General Services Administration (GSA), in consultation with the Secretary of Commerce (Commerce), regarding the modernization of Federal Information Technology (IT). In accordance with EO 13,800 the IT Modernization report was drafted and submitted to the President.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In particular, the ATC/signatory agencies are interested in responses to the fol
 
 5. What is the feasibility of the [proposed acquisition pilot](https://itmodernization.cio.gov/report/appendices/acquisition-pilot/)?
 
-**The comment period is closed.** All submitted comments during this period will be [**publicly posted here**](https://github.com/GSA/modernization/issues){:target="_blank"}.
+**The comment period is closed.** All submitted comments during this period will be <a href="https://github.com/GSA/modernization/issues" target="_blank">**publicly posted here**</a>.
 
 
 ## Development of the report website itself


### PR DESCRIPTION
The syntax used was for `kramdown`, when `markdown` doesn't support that syntax.