### PR TITLE
Update old whitehouse.gov draft link, add whitehouse.gov final link

### DIFF
--- a/pages/report/00-introduction-to-the-report.md
+++ b/pages/report/00-introduction-to-the-report.md
@@ -12,7 +12,8 @@ Read this [web-friendly version of the final report](/report/preface/) by using 
 **References:**
 
 * <a href="{{ site.report_url }}">Final Report on IT Modernization</a>
+* [White House announcement of final report](https://www.whitehouse.gov/articles/final-modernization-report/)
 * <a href="{{ site.draft_url }}">Draft Report on IT Modernization</a>
-* [White House announcement of draft report](https://www.whitehouse.gov/blog/2017/08/30/it-modernization)
+* [White House announcement of draft report](https://www.whitehouse.gov/articles/it-modernization/)
 
 [1]: https://www.whitehouse.gov/the-press-office/2017/05/11/presidential-executive-order-strengthening-cybersecurity-federal


### PR DESCRIPTION
This adds a link to the [White House's blog post announcing the final report](https://www.whitehouse.gov/articles/final-modernization-report/), and updates the link to the draft post (which changed when whitehouse.gov deployed a design overhaul).